### PR TITLE
Fix float-right by wrapping sections in block container

### DIFF
--- a/pages/cv.tsx
+++ b/pages/cv.tsx
@@ -120,22 +120,24 @@ const Cv = () => {
             {meta?.meta?.title}
           </h1>
           <NavBar className="hidden print:block" />
-          {githubProfile && (
-            <img
-              alt="ME!"
-              className="float-right ml-4 mb-2 w-[140px] h-[140px] sm:w-[220px] sm:h-[220px] rounded-full print:hidden"
-              src={`https://github.com/${githubProfile}.png`}
-            />
-          )}
-          {cv?.map((el) => (
-            <CvSection
-              key={el.meta.title}
-              content={el.content}
-              collapsable={el.meta?.collapsable}
-              level={el.meta?.level}
-              title={el.meta.title}
-            />
-          ))}
+          <div className="overflow-hidden">
+            {githubProfile && (
+              <img
+                alt="ME!"
+                className="float-right ml-4 mb-2 w-[140px] h-[140px] sm:w-[220px] sm:h-[220px] rounded-full print:hidden"
+                src={`https://github.com/${githubProfile}.png`}
+              />
+            )}
+            {cv?.map((el) => (
+              <CvSection
+                key={el.meta.title}
+                content={el.content}
+                collapsable={el.meta?.collapsable}
+                level={el.meta?.level}
+                title={el.meta.title}
+              />
+            ))}
+          </div>
         </>
       ) : <Loader />}
     </div>


### PR DESCRIPTION
float is ignored on direct children of flex containers, so the avatar
wasn't floating right — it just dropped into the column flow. Wrap the
avatar img and sections map in a plain overflow-hidden div so float-right
works and the image sits to the right of TL;DR and Personal Profile.

https://claude.ai/code/session_01G7fpAbwZ2nEdfqeG8dY6C9