### PR TITLE
Add Dev Container configuration and environment setup guide (#169)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,54 @@
+{
+  "name": "sradams.co.uk",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+
+  // Installs dependencies and triggers husky install via the prepare script
+  "postCreateCommand": "npm install",
+
+  // Starts the dev server in the background on every Codespace open/resume.
+  // Logs available at /tmp/next-dev.log
+  "postStartCommand": "nohup npm run dev > /tmp/next-dev.log 2>&1 &",
+
+  "portsAttributes": {
+    "3000": {
+      "label": "Dev Server",
+      "onAutoForward": "openBrowser"
+    }
+  },
+
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "bradlc.vscode-tailwindcss",
+        "ms-vscode.vscode-typescript-next",
+        "eamodio.gitlens"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "[typescript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[typescriptreact]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[javascript]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        },
+        "[javascriptreact]": {
+          "editor.defaultFormatter": "esbenp.prettier-vscode"
+        }
+      }
+    }
+  },
+
+  // Pass NEXT_PUBLIC_GITHUB_PROFILE through from a Codespace secret if set.
+  // Falls back to "adamsuk" via default-env.ts if not set.
+  // NEXT_PUBLIC_CMS_URL is intentionally omitted — see .env.local.example for
+  // details on the CORS limitation when running in a Codespace preview.
+  "remoteEnv": {
+    "NEXT_PUBLIC_GITHUB_PROFILE": "${localEnv:NEXT_PUBLIC_GITHUB_PROFILE}"
+  }
+}

--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,18 @@
+# Copy this file to .env.local and adjust values for local or Codespace development.
+# .env.local is git-ignored — never commit it.
+
+# Your GitHub username. Used to fetch the profile README for the homepage bio.
+# Defaults to "adamsuk" if not set.
+NEXT_PUBLIC_GITHUB_PROFILE=adamsuk
+
+# URL of the headless CMS API for blog posts and CV content.
+# Defaults to https://blog.sradams.co.uk/api if not set.
+#
+# CORS NOTE (Codespaces): The production CMS at blog.sradams.co.uk does not
+# allow requests from *.app.github.dev preview URLs. Blog and CV content will
+# fail to load in the Codespace browser preview until one of:
+#   1. The Codespace origin is added to the CMS CORS allowed-origins list.
+#   2. A local or staging CMS instance is used instead.
+#   3. A Next.js rewrites()-based proxy is added to next.config.js
+#      (works during `next dev` only — the project uses static export for builds).
+NEXT_PUBLIC_CMS_URL=https://blog.sradams.co.uk/api


### PR DESCRIPTION
* Add GitHub Codespaces devcontainer configuration

- Node 20 devcontainer image matching .nvmrc
- npm install on postCreate (also triggers husky install)
- Port 3000 forwarded and labelled "Dev Server"
- ESLint, Prettier, Tailwind IntelliSense, TypeScript, GitLens extensions
- formatOnSave with Prettier as default formatter for TS/JS/TSX/JSX
- .env.local.example documents env vars and CORS limitation with CMS

https://claude.ai/code/session_01U3zCpzLY5bCeQtj2UJN3fZ

* Auto-start dev server and open browser in Codespaces

- postStartCommand runs `npm run dev` in the background on every Codespace open/resume (logs to /tmp/next-dev.log)
- onAutoForward changed to "openBrowser" so a browser tab opens automatically once port 3000 is ready

https://claude.ai/code/session_01U3zCpzLY5bCeQtj2UJN3fZ

* Use nohup to keep dev server alive after shell exits

Without nohup, the background process receives SIGHUP when the parent shell exits, killing it before it can bind to port 3000. This prevented both the hot-reloading server and the auto browser-open from working.

https://claude.ai/code/session_01U3zCpzLY5bCeQtj2UJN3fZ

* Remove static forwardPorts so onAutoForward fires correctly

With port 3000 in forwardPorts, Codespaces tunnels it immediately at container start (before the dev server is listening). onAutoForward fires at that moment — browser opens to a connection error — and never fires again when the server actually becomes ready.

Removing forwardPorts lets Codespaces auto-detect port 3000 the moment the dev server starts listening, which is the correct trigger point for onAutoForward: "openBrowser".

https://claude.ai/code/session_01U3zCpzLY5bCeQtj2UJN3fZ

---------